### PR TITLE
Bugfix/bot disconnect and reconnect to voice channel repeatedly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,8 @@ repositories {
 }
 
 dependencies {
-    implementation("net.dv8tion:JDA:5.0.0-alpha.22")
-    implementation("com.github.minndevelopment:jda-ktx:0.9.5-alpha.19")
+    implementation("net.dv8tion:JDA:5.0.0-beta.8")
+    implementation("com.github.minndevelopment:jda-ktx:0.10.0-beta.1")
     implementation("com.sedmelluq:lavaplayer:1.3.78")
 
     testImplementation(kotlin("test"))

--- a/src/main/kotlin/com/gacagebot/constants/Constants.kt
+++ b/src/main/kotlin/com/gacagebot/constants/Constants.kt
@@ -1,7 +1,0 @@
-package com.gacagebot.constants
-
-object Constants {
-    const val BOT_TOKEN: String = "Your bot token here"
-    const val DJ_GCAGE: String = "*DJ Gcage*"
-    const val CHANNEL_ID: String = "If necessary"
-}


### PR DESCRIPTION
Fix bot disconnecting and reconnecting to voice channel.

This bug was most likely caused by changes made to the discord voice connections:
 
Discord api-annauncementes "Starting March 15, 2023, all apps with Voice Connections using IP Discovery must send 74-byte UDP packets. IP Discovery requests sending the deprecated 70-byte packet will no longer receive a response."

more details see: https://discord.com/developers/docs/topics/voice-connections#ip-discovery